### PR TITLE
allow user agent test regex from options

### DIFF
--- a/lib/connect-s4a.js
+++ b/lib/connect-s4a.js
@@ -49,8 +49,15 @@ module.exports = function (token, options) {
             return serveCapture();
         if (parsedUrl.path && !parsedUrl.path.match(/index\.html?/i) && parsedUrl.path.match(/.*(\.[^?]{2,4}$|\.[^?]{2,4}?.*)/))
             return next();
-        if (req.headers['user-agent'] && req.headers['user-agent'].match(userAgentTest))
-            return serveCapture();
+        if (
+          req.headers['user-agent'] &&
+          req.headers['user-agent'].match(
+            options && options.userAgentTest
+              ? options.userAgentTest
+              : userAgentTest
+          )
+        )
+          return serveCapture();
         return next();
     };
 };

--- a/tests/connect.js
+++ b/tests/connect.js
@@ -692,6 +692,119 @@ exports["urls filtered by user-agent properly proxied"] = {
 
 };
 
+exports[
+  "urls filtered by user-agent properly proxied only for user-agents from options"
+] = {
+  setUp: function (ready) {
+    var s4aAPI = connect();
+    s4aAPI.use(function (req, res) {
+      var path = url.parse(req.url).path;
+      res.setHeader("Server", "api");
+      res.end(path);
+    });
+    this.apiServer = s4aAPI.listen(3001);
+
+    var app = connect();
+    app.use(
+      connect_s4a(s4aToken, {
+        apiEndPoint: 'http://localhost:3001/',
+        userAgentTest: /(mail\.ru)/gi,
+      })
+    );
+    app.use(function (req, res) {
+      res.setHeader('Server', 'app');
+      res.end('connect server');
+    });
+    this.connectServer = app.listen(3000);
+
+    ready();
+  },
+  tearDown: function (done) {
+    var self = this;
+    self.apiServer.close(function () {
+      self.connectServer.close(function () {
+        done();
+      });
+    });
+  },
+  'Google bot': function (test) {
+    var path = '/path/subpath';
+    var uri = 'http://localhost:3000' + path;
+    var requestObj = {
+      uri: uri,
+      headers: {
+        'User-Agent':
+          'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+      },
+    };
+    test.expect(1);
+    request.get(requestObj, function (err, resp, body) {
+      if (err) {
+        test.ok(false, 'the request is in error : ' + err);
+        test.done();
+      } else {
+        test.equals(
+          body,
+          'connect server',
+          'the request should have been answered by the original server'
+        );
+        test.done();
+      }
+    });
+  },
+  'Google bot mobile': function (test) {
+    var path = '/path/subpath';
+    var uri = 'http://localhost:3000' + path;
+    var requestObj = {
+      uri: uri,
+      headers: {
+        'User-Agent':
+          'Mozilla/5.0 (iPhone; CPU iPhone OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5376e Safari/8536.25 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+      },
+    };
+    test.expect(1);
+    request.get(requestObj, function (err, resp, body) {
+      if (err) {
+        test.ok(false, 'the request is in error : ' + err);
+        test.done();
+      } else {
+        test.equals(
+          body,
+          'connect server',
+          'the request should have been answered by the original server'
+        );
+        test.done();
+      }
+    });
+  },
+  'Mail.RU bot': function (test) {
+    var path = '/path/subpath';
+    var uri = 'http://localhost:3000' + path;
+    var requestObj = {
+      uri: uri,
+      headers: {
+        'User-Agent':
+          'Mozilla/5.0 (compatible; Linux x86_64; Mail.RU_Bot/2.0; +http://go.mail.ru/help/robots)',
+      },
+    };
+    test.expect(1);
+    request.get(requestObj, function (err, resp, body) {
+      if (err) {
+        test.ok(false, 'the request is in error : ' + err);
+        test.done();
+      } else {
+        test.equals(
+          body,
+          '/' + s4aToken + path,
+          'the request should have been answered by the s4a api server'
+        );
+        test.done();
+      }
+    });
+  },
+};
+
+
 exports['header properly sent'] = {
     setUp: function (ready) {
         var s4aAPI = connect();


### PR DESCRIPTION
We are thinking of doing s4a only for specific bots and there is nothing for that in this package. so I added UA test regex to options. so if it is present, then it will use that regex, if not, then default one with all the bots.

Would be nice to have an option to exclude specific bots. but this would require generating dynamic regex. I was not sure if you would like that. If that makes sense, then I can also work on these feature: to specify bots you want to exclude.